### PR TITLE
Support iOS Simulator Touch ID

### DIFF
--- a/BiometricAuthenticator/Classes/Utility/UIDeviceExtension.swift
+++ b/BiometricAuthenticator/Classes/Utility/UIDeviceExtension.swift
@@ -29,7 +29,6 @@ internal extension UIDevice {
     /// that don't support Touch ID.
     func supportsTouchId() -> Bool {
         let invalidModels = [
-            "x86_64",                   // Simulator
             "iPhone4,1",                // iPhone 4S
             "iPhone5,1", "iPhone5,2",   // iPhone 5
             "iPhone5,3", "iPhone5,4",   // iPhone 5C


### PR DESCRIPTION
Removed simulator (x86_64) device from unsupported Touch ID `invalidModels` array.  The simulator does support Touch ID.